### PR TITLE
fix: In latest iOS version property "downloadable" has been removed a…

### DIFF
--- a/ios/RNPayments/RNPayments.m
+++ b/ios/RNPayments/RNPayments.m
@@ -255,7 +255,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTPromiseResolveBlock)resolve
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                                       @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
-                                      @"downloadable": item.downloadable ? @"true" : @"false" ,
+                                      @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                                       };
             [productsArrayForJS addObject:product];
         }


### PR DESCRIPTION
…nd for a while now (since iOS 6) replaced with "isDownloadable"