### PR TITLE
fix: remove nonNull annotations

### DIFF
--- a/android/src/main/java/com/dicetechnology/rnpayments/RNPaymentsAmazonModule.java
+++ b/android/src/main/java/com/dicetechnology/rnpayments/RNPaymentsAmazonModule.java
@@ -1,7 +1,6 @@
 package com.dicetechnology.rnpayments;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
 
 import com.amazon.device.iap.PurchasingListener;
 import com.amazon.device.iap.PurchasingService;
@@ -173,7 +172,6 @@ public class RNPaymentsAmazonModule extends ReactContextBaseJavaModule {
         registerListener(reactContext);
     }
 
-    @NonNull
     @Override
     public String getName() {
         return "RNPaymentsAmazonModule";

--- a/android/src/main/java/com/dicetechnology/rnpayments/RNPaymentsPackage.java
+++ b/android/src/main/java/com/dicetechnology/rnpayments/RNPaymentsPackage.java
@@ -2,7 +2,6 @@ package com.dicetechnology.rnpayments;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.support.annotation.NonNull;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
@@ -27,10 +26,9 @@ public class RNPaymentsPackage implements ReactPackage {
     public RNPaymentsPackage() {
     }
 
-    @NonNull
     @Override
     public List<NativeModule> createNativeModules(
-            @NonNull ReactApplicationContext reactContext
+        ReactApplicationContext reactContext
     ) {
         List<NativeModule> modules = new ArrayList<>();
 
@@ -45,9 +43,8 @@ public class RNPaymentsPackage implements ReactPackage {
         return modules;
     }
 
-    @NonNull
     @Override
-    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-payments",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Wrapper for react-native iOS in-app-purchases and Android in-app-billing.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We are using this pkg in the tv project for android TVs. the tv app fails to build because it uses android x. The build error is:

```
error: package com.android.annotations does not exist
```

This package is needed to add @NonNull annotations.  I think we can safely remove the use of @NonNull annotations in the codebase without affecting the functionality.

with this change, the tv app builds successfully. 